### PR TITLE
Verify SSL certificates for requests

### DIFF
--- a/beowebclient/common/client.py
+++ b/beowebclient/common/client.py
@@ -46,7 +46,7 @@ class HTTPClient(object):
                 for param in kwargs:
                     LOG.debug("DEBUG %s, %s=%s", method, param, kwargs[param])
                 del kwargs['debug']
-            resp = self.client.request(method, fullurl, verify=False, **kwargs)
+            resp = self.client.request(method, fullurl, **kwargs)
         except requests.exceptions.ConnectionError:
             LOG.error("Unable to connect to %s", self.endpoint, exc_info=True)
             raise beowebexc.BeowebConnectError(

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ if pyversion < (2, 6):
 
 setup(
     name="python-beoweb-client",
-    version="0.1.1",
+    version="0.1.2",
     description="Client library for Scyld Beoweb API",
     classifiers=[
         "Programming Language :: Python",


### PR DESCRIPTION
Modern Python libraries complain if SSL certificates aren't checked, and SSL certificates are free and easy, so always verify requests.